### PR TITLE
Fixed error / help message when x11docker is run as root

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -603,7 +603,7 @@ s0_active_plugins = core;composite;opengl;decor;resize;move;
   the new X server would get root privileges, too. To run docker, you will be
   prompted for your root password only for this one command.
   On systems without a root password, like Ubuntu, choose option '-s, --sudo'
-  If you want to allow root to run x11docker, use option '-r, --root'"
+  If you want to allow root to run x11docker, use option '--root'"
     fi
   else
     if [ "0" = "$(id -u)" ] ; then GETROOT="" ; fi   # if running as root and it is allowed, then disable password prompt


### PR DESCRIPTION
Hi there, and thanks for this tool!

The help message when running x11docker as root suggests using either the -r or --root options to allow running as root.

However, the -r option does not allow execution as root, but rather makes the Xephyr window resizable.