### PR TITLE
fixed compatibility with local user naming policy and added workaround for a sparse file handling in device mapper 

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -1101,8 +1101,8 @@ s0_active_plugins = core;composite;opengl;decor;resize;move;
         #
         { echo "#! /bin/bash"
           # create user
-          echo "addgroup --gid `id -g $Benutzer` $Benutzer"
-          echo "adduser --disabled-password  --uid `id -u` --gid `id -g` --gecos " '""' " --home /home/$Benutzer $Benutzer"
+          echo "addgroup --force-badname --gid `id -g $Benutzer` $Benutzer"
+          echo "useradd -l --password '' --uid `id -u` --gid `id -g` --create-home --home-dir /home/$Benutzer $Benutzer"
           echo "chown $Benutzer:$Benutzer /home/$Benutzer"
           echo "HOME=/home/$Benutzer"
       


### PR DESCRIPTION
added --force-badname for compatibility with local user naming policy
switched to 'useradd -l' as a workaround for https://github.com/docker/docker/issues/5419