### PR TITLE
--gpu and --alsa options don't respect host ownership of devices in /dev/snd and /dev/dri

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -3545,10 +3545,10 @@ start() {
       ## option --gpu : share graphics adapter device files
       [ "$Gpu" = "yes" ] && {
         Dockercommand="$Dockercommand \\
-  --device=/dev/dri:/dev/dri:rw"
+  --device=/dev/dri:/dev/dri:rw -v /dev/dri:/dev/dri"
         for Line in $(find /dev/nvidia* /dev/vga_arbiter -maxdepth 0 2>/dev/null) ; do
           Dockercommand="$Dockercommand \\
-  --device=$Line:$Line:rw"
+  --device=$Line:$Line:rw -v $Line:$Line"
         done
       }
       
@@ -3562,7 +3562,7 @@ start() {
   --net=none"
       ## option --alsa      
       [ "$Alsa" = "yes" ]          && Dockercommand="$Dockercommand \\
-  --device=/dev/snd:/dev/snd:rw"
+  --device=/dev/snd:/dev/snd:rw -v /dev/snd:/dev/snd"
         
       # add custom docker arguments, imagename and imagecommand
       Dockercommand="$Dockercommand \\


### PR DESCRIPTION
I'm enjoying the use of x11docker to run [Kodi](https://kodi.tv/) and, with the exception of a few kinks that need to be ironed out, it's been working great for the past few months.

This week, my sound stopped working and the video suddenly looked choppy. In the course of debugging, I found that the problem was related to the container's permissions of `/dev/snd/*` and `/dev/dri/*`. The good news is that I believe I found a simple fix that you might want to consider.

On my host, the items in `/dev/snd` and `/dev/dri` have group ownership of `audio` and `video`. I *think* that's pretty standard for (at least) Debian-based distros..

```bash
$ ls -alh /dev/snd /dev/dri
/dev/dri:
total 0
drwxr-xr-x  2 root root       100 Mar  1 20:04 .
drwxr-xr-x 19 root root      3.3K Mar  1 20:04 ..
crw-rw----  1 root video 226,   0 Mar  1 20:25 card0
crw-rw----  1 root video 226,  64 Mar  1 20:04 controlD64
crw-rw----  1 root video 226, 128 Mar  1 20:04 renderD128

/dev/snd:
total 0
drwxr-xr-x  3 root root      300 Mar  1 20:04 .
drwxr-xr-x 19 root root     3.3K Mar  1 20:04 ..
drwxr-xr-x  2 root root       60 Mar  1 20:04 by-path
crw-rw----  1 root audio 116,  2 Mar  1 20:04 controlC0
crw-rw----  1 root audio 116, 10 Mar  1 20:04 hwC0D0
crw-rw----  1 root audio 116, 11 Mar  1 20:04 hwC0D2
crw-rw----  1 root audio 116,  4 Mar  1 20:04 pcmC0D0c
crw-rw----  1 root audio 116,  3 Mar  1 21:58 pcmC0D0p
crw-rw----  1 root audio 116,  5 Mar  1 20:04 pcmC0D1p
crw-rw----  1 root audio 116,  6 Mar  1 20:04 pcmC0D2c
crw-rw----  1 root audio 116,  7 Mar  1 21:59 pcmC0D3p
crw-rw----  1 root audio 116,  8 Mar  1 20:04 pcmC0D7p
crw-rw----  1 root audio 116,  9 Mar  1 20:04 pcmC0D8p
crw-rw----  1 root audio 116,  1 Mar  1 20:04 seq
crw-rw----  1 root audio 116, 33 Mar  1 20:04 timer
```

But in the container, if you inspect those same directories, you'll see that the items have `root:root` ownership:

```
$ docker run -it --rm --device /dev/snd:/dev/snd --device /dev/dri:/dev/dri ubuntu 
root@1a34f22340ad:/# ls -alh /dev/snd /dev/dri
/dev/dri:
total 0
drwxr-xr-x 2 root root      100 Mar  2 06:12 .
drwxr-xr-x 7 root root      400 Mar  2 06:12 ..
crw-rw---- 1 root root 226,   0 Mar  2 06:12 card0
crw-rw---- 1 root root 226,  64 Mar  2 06:12 controlD64
crw-rw---- 1 root root 226, 128 Mar  2 06:12 renderD128

/dev/snd:
total 0
drwxr-xr-x 2 root root     280 Mar  2 06:12 .
drwxr-xr-x 7 root root     400 Mar  2 06:12 ..
crw-rw---- 1 root root 116,  2 Mar  2 06:12 controlC0
crw-rw---- 1 root root 116, 10 Mar  2 06:12 hwC0D0
crw-rw---- 1 root root 116, 11 Mar  2 06:12 hwC0D2
crw-rw---- 1 root root 116,  4 Mar  2 06:12 pcmC0D0c
crw-rw---- 1 root root 116,  3 Mar  2 06:12 pcmC0D0p
crw-rw---- 1 root root 116,  5 Mar  2 06:12 pcmC0D1p
crw-rw---- 1 root root 116,  6 Mar  2 06:12 pcmC0D2c
crw-rw---- 1 root root 116,  7 Mar  2 06:12 pcmC0D3p
crw-rw---- 1 root root 116,  8 Mar  2 06:12 pcmC0D7p
crw-rw---- 1 root root 116,  9 Mar  2 06:12 pcmC0D8p
crw-rw---- 1 root root 116,  1 Mar  2 06:12 seq
crw-rw---- 1 root root 116, 33 Mar  2 06:12 timer
```
The result is that the processes started by x11docker, which are non-root of course, can't read/write to these devices. In my case, that results in Kodi not being able to utilize hardware video acceleration and output *any* sound.

So for some reason `--device` makes the respective devices `root:root` in the container, but we need it to respect at least the group ownership. I found [this comment](https://github.com/moby/moby/issues/10184#issuecomment-72106700) which suggested adding `-v` in addition to `--device`. I tried that and **boom**:

```
docker run -it --rm --device /dev/snd:/dev/snd --device /dev/dri:/dev/dri -v /dev/dri:/dev/dri -v /dev/snd:/dev/snd ubuntu 
root@9c56a28761a6:/# ls -alh /dev/snd /dev/dri
/dev/dri:
total 0
drwxr-xr-x 2 root root       100 Mar  2 04:04 .
drwxr-xr-x 7 root root       400 Mar  2 06:23 ..
crw-rw---- 1 root video 226,   0 Mar  2 04:25 card0
crw-rw---- 1 root video 226,  64 Mar  2 04:04 controlD64
crw-rw---- 1 root video 226, 128 Mar  2 04:04 renderD128

/dev/snd:
total 0
drwxr-xr-x 3 root root      300 Mar  2 04:04 .
drwxr-xr-x 7 root root      400 Mar  2 06:23 ..
drwxr-xr-x 2 root root       60 Mar  2 04:04 by-path
crw-rw---- 1 root audio 116,  2 Mar  2 04:04 controlC0
crw-rw---- 1 root audio 116, 10 Mar  2 04:04 hwC0D0
crw-rw---- 1 root audio 116, 11 Mar  2 04:04 hwC0D2
crw-rw---- 1 root audio 116,  4 Mar  2 04:04 pcmC0D0c
crw-rw---- 1 root audio 116,  3 Mar  2 05:58 pcmC0D0p
crw-rw---- 1 root audio 116,  5 Mar  2 04:04 pcmC0D1p
crw-rw---- 1 root audio 116,  6 Mar  2 04:04 pcmC0D2c
crw-rw---- 1 root audio 116,  7 Mar  2 06:20 pcmC0D3p
crw-rw---- 1 root audio 116,  8 Mar  2 04:04 pcmC0D7p
crw-rw---- 1 root audio 116,  9 Mar  2 04:04 pcmC0D8p
crw-rw---- 1 root audio 116,  1 Mar  2 04:04 seq
crw-rw---- 1 root audio 116, 33 Mar  2 04:04 timer
```
I don't know if that's a bug in Docker, or if there's a "better" way to get Docker to respect permissions of raw devices. Nor do I know why I'm only now seeing these issues. But I *do* know that adding `-v /dev/snd:/dev/snd` and `-v /dev/dri:/dev/dri` fixes things for me.

[Here's](https://pastebin.com/raw/pjBsxGyT) a copy of my latest `x11docker.log`. In the "Created docker command" area you can see that I added my workaround.

Thoughts?