### PR TITLE
Fix writeaccess() for user/group names with spaces in it

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -920,8 +920,8 @@ isnum() {               # check if $1 is a number
   [ "1" = "$(awk -v a="${1:-}" 'BEGIN {print (a == a + 0)}')" ]
 }
 writeaccess() {         # check if useruid $1 has write access to folder $2
-  local dirVals gMember
-  if read -a dirVals < <(stat -Lc "%U %G %A" "${2:-}") && (
+  local dirVals gMember IFS
+  if IFS="	" read -a dirVals < <(stat -Lc "%U	%G	%A" "${2:-}") && (
     ( [ "$(id -u $dirVals)" == "${1:-}" ] && [ "${dirVals[2]:2:1}" == "w" ] ) ||
     ( [ "${dirVals[2]:8:1}" == "w" ] ) ||
     ( [ "${dirVals[2]:5:1}" == "w" ] && (


### PR DESCRIPTION
I encountered a bug because my default group on my work PC is "Domain Users". Therefore the output from `stat` is split in the wrong way.

I fixed this by changing the delimiters to TAB-characters and setting `IFS` to TAB temporarily.