### PR TITLE
Fixes #178

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -4520,7 +4520,7 @@ $Wmdockercommand"'
   echo "  $Dockerexe exec $Containername sh -c : 2>&1 | rmcr >>$Containerlogfile && { debugnote 'Container is up and running.' ; break ; } || debugnote \"Container not ready on \$Count. attempt, trying again.\""
   echo "  mysleep 0.2"
   echo "done"
-  echo "$Dockerexe logs -f \$Containerid 2>&1 > >(rmcr >> $Containerlogfile) & storepid $! dockerlogs"
+  echo "$Dockerexe logs -f \$Containerid 2>&1 > >(rmcr >> $Containerlogfile) & storepid \$! dockerlogs"
   
   echo "for ((Count=1 ; Count<=20 ; Count++)); do"
   echo "  Pid1pid=\"\$($Dockerexe inspect --format '{{.State.Pid}}' $Containername 2>>$Containerlogfile | rmcr)\""

--- a/x11docker
+++ b/x11docker
@@ -521,6 +521,7 @@ $(cat $Bgpidfile 2>/dev/null)"
           catstdin)               killpid $Pid $Name ;;
           hostexe|shareclipboard) killpid $Pid $Name bash ;;
           xfishtank)              killpid $Pid $Name xfishtank ;;
+          dockerlogs)             $Sudo killpid $Pid $Name ;;
           containerpid1)
             Pid1pid="$Pid"
             Pid=
@@ -4519,7 +4520,7 @@ $Wmdockercommand"'
   echo "  $Dockerexe exec $Containername sh -c : 2>&1 | rmcr >>$Containerlogfile && { debugnote 'Container is up and running.' ; break ; } || debugnote \"Container not ready on \$Count. attempt, trying again.\""
   echo "  mysleep 0.2"
   echo "done"
-  echo "$Dockerexe logs -f \$Containerid 2>&1 | rmcr >> $Containerlogfile &"
+  echo "$Dockerexe logs -f \$Containerid 2>&1 > >(rmcr >> $Containerlogfile) & storepid $! dockerlogs"
   
   echo "for ((Count=1 ; Count<=20 ; Count++)); do"
   echo "  Pid1pid=\"\$($Dockerexe inspect --format '{{.State.Pid}}' $Containername 2>>$Containerlogfile | rmcr)\""


### PR DESCRIPTION
Fixes #178 by using a subshell redirect so the captured pid is that of `docker logs. Based on https://github.com/mviereck/x11docker/commit/79980c6cbd95af76e6f29e2e6a7b0bca6c8ab0ac