### PR TITLE
Add support: sudo with nopasswd

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -227,9 +227,10 @@ Special options:
      --workdir DIR     Set working directory DIR.
 
 User settings:
-     --sudouser        Allow su and sudo for container user. Use with care,
+     --sudouser [=nopasswd] Allow su and sudo for container user. Use with care,
                        severe reduction of default x11docker security!
                          Password:  x11docker
+                       --sudouser=nopasswd will allow sudo without prompt password
      --user N          Create container user N (N=name or N=uid). Default:
                        same as host user. N can also be an unknown user id.
                        You can specify a group id with N being 'user:gid'.
@@ -3950,6 +3951,7 @@ check_containeruser() {         # check container user and shared home folder (a
     Containerusergroup="root"
     Containeruserhosthome="/root"
     Sudouser="yes" && note "Option --user=root: Enabling option --sudouser."
+    Sudouser="nopasswd" && note "Option --user=root: Enabling option --sudouser=nopasswd."
   }
   
   debugnote "container user: $Containeruser $Containeruseruid:$Containerusergid $Containeruserhosthome"
@@ -4236,7 +4238,7 @@ create_dockercommand() {        ### create command to run docker
 setup_capabilities() {          # check linux capabilities needed by container
   # compare: man capabilities
 
-  [ "$Sudouser" = "yes" ]       && Adminusercaps="yes"
+  [ "$Sudouser" = "yes" ] || [ "$Sudouser" = "nopasswd" ]       && Adminusercaps="yes"
   [ "$Capdropall" = "no" ]      && [ "$Allownewprivileges" = "auto" ] && { 
     note "Option --cap-default: Enabling option --newprivileges=yes.
   You can avoid this with --newprivileges=no"
@@ -4244,7 +4246,7 @@ setup_capabilities() {          # check linux capabilities needed by container
   }
   
   # --sudouser
-  [ "$Sudouser" = "yes" ] && warning "Option --sudouser severly reduces container security.
+  [ "$Sudouser" = "yes" ] || [ "$Sudouser" = "nopasswd" ] && warning "Option --sudouser severly reduces container security.
   Container gains additional capabilities to allow sudo and su.
   If an application breaks out of container, it can harm your system
   in many ways without you noticing. Password: x11docker"
@@ -4687,7 +4689,7 @@ create_containerrootrc() {      ### create containerrootrc: This script runs as 
       echo "echo \"$Containeruser:$Containeruserpassword:17293:0:99999:7:::\" > /etc/shadow"
       case $Sudouser in
         no)  echo "echo 'root:*:17219:0:99999:7:::' >> /etc/shadow" ;;
-        yes) echo "echo 'root:$Containeruserpassword:17219:0:99999:7:::' >> /etc/shadow  # with option --sudouser, set root password 'x11docker'"
+        yes|nopasswd) echo "echo 'root:$Containeruserpassword:17219:0:99999:7:::' >> /etc/shadow  # with option --sudouser, set root password 'x11docker'"
              echo "sed -i 's%root:-:%root:x:%' /etc/passwd                               # allow password in /etc/shadow"
         ;;
       esac
@@ -4705,6 +4707,7 @@ create_containerrootrc() {      ### create containerrootrc: This script runs as 
       echo "echo '# /etc/sudoers created by x11docker' > /etc/sudoers"
       echo "echo 'root ALL=(ALL) ALL'                 >> /etc/sudoers"
       [ "$Sudouser" = "yes" ] && echo "echo '$Containeruser ALL=(ALL) ALL' >> /etc/sudoers"
+      [ "$Sudouser" = "nopasswd" ] && echo "echo '$Containeruser ALL=NOPASSWD:ALL' >> /etc/sudoers"
       echo ""
 
       # try to disable possible custom PAM setups that could allow switch to root in container
@@ -7670,7 +7673,7 @@ option_messages() {             # some messages depending on options, but not ch
   # --user=RETAIN / keep container defined in image
   case $Createcontaineruser in
     no)
-      [ "$Sudouser" = "yes" ] && note "Option --sudouser has limited support with --user=RETAIN.
+      [ "$Sudouser" = "yes" || "$Sudouser" = "nopasswd" ] && note "Option --sudouser has limited support with --user=RETAIN.
   x11docker will only set needed capabilities. 
   User setup and /etc/sudoers won't be touched.
   Option --group-add=sudo might be useful."
@@ -8082,7 +8085,7 @@ declare_variables() {           # declare global variables
   Sharehostipc="no"                               # --hostipc: Set --ipc=host.
   Sharehostnet="no"                               # --hostnet: Set --network=host
   Stopsignal=""                                   # Signal to send on 'docker stop'
-  Sudouser="no"                                   # --sudouser: Create user with sudo permissions and root user with password 'x11docker'
+  Sudouser="no"                                   # --sudouser: Create user with sudo permissions and root user with password 'x11docker', or --sudouser=nopasswd for sudo without promote password
   Switchcontaineruser="no"                        # --init=systemd|openrc|runit|sysvinit: User switching to trigger login services yes/no
   Switchcontainerusercaps="no"                    # --init=systemd|openrc|runit|sysvinit, --sudouser, --user=root: Add capabilities for su/sudo user switching
   Systemdconsoleservice="systemd.console-getty.service" # --init=systemd
@@ -8227,7 +8230,7 @@ parse_options() {               # parse cli options
   Longoptions="$Longoptions,alsa::,clipboard,gpu,lang::,printer::,pulseaudio::,webcam"                                     # Host integration features
   Longoptions="$Longoptions,env:,mobyvm,name:,no-entrypoint,runtime:,workdir:"                                             # Container config
   Longoptions="$Longoptions,cap-default,hostipc,hostnet,limit::,newprivileges::,no-internet"                               # Container capabilities
-  Longoptions="$Longoptions,group-add:,hostuser:,sudouser,user:,shell:"                                                    # Container user
+  Longoptions="$Longoptions,group-add:,hostuser:,sudouser::,user:,shell:"                                                    # Container user
   Longoptions="$Longoptions,dbus::,init::,hostdbus,sharecgroup"                                                            # Container init and DBus
   Longoptions="$Longoptions,stdin,interactive"                                                                             # Container interaction
   Longoptions="$Longoptions,runfromhost:,runasroot:"                                                                       # Additional commands to execute
@@ -8399,7 +8402,13 @@ ${2:-}"                       ; shift ;;                             # Add custo
          --group-add)         Containerusergroups="$Containerusergroups ${2:-}" ; shift ;; # Additional groups for container user
          --hostuser)          Hostuser="${2:-}" ; shift ;;           # Set host user different from logged in user
          --shell)             Containerusershell="${2:-}" ; shift ;; # Set preferred user shell
-         --sudouser)          Sudouser="yes" ;;                      # su and sudo for container user with password x11docker
+         --sudouser)          case "${2:-}" in                       # su and sudo for container user with password x11docker
+                                yes|"") Sudouser="yes" ;;
+                                nopasswd) Sudouser="nopasswd" ;;     # --sudouser=nopasswd to enable sudo without promote password
+                                no)     Sudouser="no" ;;
+                                *) warning "Invalid argument for option --sudouser [=yes|nopasswd|no]: ${2:-}" ;;
+                              esac; shift ;;       
+                              
          --user)              Containeruser="${2:-}"  ; shift        # Set container user other than host user
                               [ "$Containeruser" = "RETAIN" ] && Createcontaineruser="no" ;;
                


### PR DESCRIPTION
Input password every time is a little bit bother.
So here is the patch:
x11docker can start with --sudouser=nopasswd to work.
The --sudouser without [=nopasswd] also work as previous.