### PR TITLE
Fix Docker run argument --name now works

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -4014,10 +4014,8 @@ create_dockercommand() {        ### create command to run docker
   esac
 
   [ -z "$Containername" ] && Containername="x11docker_X${Newdisplaynumber}_${Codename}_${Cachenumber}"
-  Dockercommand="$Dockercommand \\
-  --name $Containername"
-  Wmdockercommand="$Wmdockercommand \\
-  --name ${Containername}_WM"
+  Dockercommand="$Dockercommand --name $Containername"
+  Wmdockercommand="$Wmdockercommand --name ${Containername}_WM"
   storeinfo "containername=$Containername"
   
   [ "$Limitresources" ] && {


### PR DESCRIPTION
--name works only on the same command line of others arguments. `\\` break the name.