### PR TITLE
[WSL2] x11docker watching unexisting pid1pid (auto close)

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -8972,7 +8972,7 @@ Parsed options:    $Parsedoptions_global"
   $Dockercommand"
     
     #### Create helper scripts to set up container
-    ## dockerrc runs as root (or member of group docker) on host.
+    ## dockerrc runs as root (or member of group docker) on host.d
     # Main jobs: check image, pull image if needed, create script containerrc to run container command
     create_dockerrc             
     verbose "Generated dockerrc:
@@ -9017,10 +9017,10 @@ $(nl -ba <$Westonini)"
     
     # watch container
     case $X11dockermode in
-      run)
-        case $Mobyvm in
-          no)  setonwatchpidlist "CONTAINER$Containername" ;;
-          yes) setonwatchpidlist "CONTAINER$Containername" ;;
+      run)  
+        case "$Winsubsystem" in
+          "") setonwatchpidlist "${Pid1pid:-NOPID}" pid1pid ;;
+          *)  setonwatchpidlist "CONTAINER$Containername" ;;
         esac
       ;;
       exe)     setonwatchpidlist "${Pid1pid:-NOPID}" pid1pid ;;

--- a/x11docker
+++ b/x11docker
@@ -9019,7 +9019,7 @@ $(nl -ba <$Westonini)"
     case $X11dockermode in
       run)
         case $Mobyvm in
-          no)  setonwatchpidlist "CONTAINER$Containername" ;; #setonwatchpidlist "${Pid1pid:-NOPID}" pid1pid ;;
+          no)  setonwatchpidlist "CONTAINER$Containername" ;;
           yes) setonwatchpidlist "CONTAINER$Containername" ;;
         esac
       ;;

--- a/x11docker
+++ b/x11docker
@@ -815,7 +815,7 @@ $(for Line in $Watchpidlist; do pspid "$Line" || echo "(pid $Line not found)" ; 
     done
     # Container PID not watchable in MSYS2/Cygwin/WSL11.
     [ "$Containername" ] && {
-      $Dockerexe inspect $Containername >/dev/null 2>&1 || {
+      [ $($Dockerexe inspect -f {{.State.Running}} $Containername) == "true" ] || {
         debugnote "watchpidlist(): Container $Containername has terminated"
         saygoodbye "watchpidlist $Containername"
       }
@@ -9019,7 +9019,7 @@ $(nl -ba <$Westonini)"
     case $X11dockermode in
       run)
         case $Mobyvm in
-          no)  setonwatchpidlist "${Pid1pid:-NOPID}" pid1pid ;;
+          no)  setonwatchpidlist "CONTAINER$Containername" ;; #setonwatchpidlist "${Pid1pid:-NOPID}" pid1pid ;;
           yes) setonwatchpidlist "CONTAINER$Containername" ;;
         esac
       ;;

--- a/x11docker
+++ b/x11docker
@@ -815,7 +815,7 @@ $(for Line in $Watchpidlist; do pspid "$Line" || echo "(pid $Line not found)" ; 
     done
     # Container PID not watchable in MSYS2/Cygwin/WSL11.
     [ "$Containername" ] && {
-      [ $($Dockerexe inspect -f {{.State.Running}} $Containername) == "true" ] || {
+      [ "$($Dockerexe inspect -f {{.State.Running}} $Containername)" == "true" ] || {
         debugnote "watchpidlist(): Container $Containername has terminated"
         saygoodbye "watchpidlist $Containername"
       }


### PR DESCRIPTION
Fix #354