### PR TITLE
Use /usr/bin/tini-static for tini if available

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -4521,6 +4521,7 @@ setup_initsystem() {            # option init: set up capabilities, check or cre
       Tinibinaryfile="$(command -v docker-init ||:)"
       [ -z "$Tinibinaryfile" ]                                      && Tinibinaryfile="/snap/docker/current/bin/docker-init"
       [ -e "$Tinibinaryfile" ]                                      || Tinibinaryfile="/snap/docker/current/usr/bin/docker-init"
+      [ -e "/usr/bin/tini-static" ]                                 && Tinibinaryfile="/usr/bin/tini-static"
       [ -e "/usr/local/share/x11docker/tini-static" ]               && Tinibinaryfile="/usr/local/share/x11docker/tini-static"
       [ -e "$Hostuserhome/.local/share/x11docker/tini-static" ]     && Tinibinaryfile="$Hostuserhome/.local/share/x11docker/tini-static"
       Tinibinaryfile="$(myrealpath "$Tinibinaryfile" 2>/dev/null ||:)"


### PR DESCRIPTION
Some distributions (e.g. Debian) ship a packaged version of `tini` in `/usr/bin/tini-static`, so use it if it's available.