### PR TITLE
Add --keep-groups switch to support using --gpu in rootless podman

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -251,6 +251,8 @@ X and Wayland special configuration:
 
 Container user settings:
      --group-add=GROUP Add container user to group GROUP.
+     --keep-groups     Expose host groups for current user to container.
+                       (Only works with rootless podman, and 'crun' backend.)
      --hostuser=USER   Run X (and container user) as user USER. Default is
                        result of \$(logname). (x11docker must run as root).
      --password [=WORD]   Change container user password and exit.
@@ -4448,14 +4450,16 @@ create_xcontainercommand() {    # option --xc: create docker command for X in co
     mkfile "$Sharefolder/nvidia_installer"
     rootrc_nvidia_installer >> "$Sharefolder/nvidia_installer"
   }
-  case "$Xcontainerbackend" in
-    docker|podman)
-      mygetent group video >/dev/null && Xc_gpu="$Xc_gpu \\
-  --group-add $(mygetent group video  | cut -d: -f3)"
-      mygetent group render >/dev/null && Xc_gpu="$Xc_gpu \\
-  --group-add $(mygetent group render | cut -d: -f3)"
-    ;;
-  esac
+  if "$Keepgroups" = "no"; then
+    case "$Xcontainerbackend" in
+      docker|podman)
+        mygetent group video >/dev/null && Xc_gpu="$Xc_gpu \\
+    --group-add $(mygetent group video  | cut -d: -f3)"
+        mygetent group render >/dev/null && Xc_gpu="$Xc_gpu \\
+    --group-add $(mygetent group render | cut -d: -f3)"
+      ;;
+    esac
+  fi
 
   # console
   Xc_console="\\
@@ -4477,12 +4481,14 @@ create_xcontainercommand() {    # option --xc: create docker command for X in co
   --cap-add CHOWN \\
   --env XDG_VTNR=$Newxvt \\
   --mount type=bind,source=$Compositorlogfile,target=/x11docker/compositor.log"
-  case "$Xcontainerbackend" in
-    docker|podman)
-      Xc_weston="$Xc_weston \\
+  if "$Keepgroups" = "no"; then
+    case "$Xcontainerbackend" in
+      docker|podman)
+        Xc_weston="$Xc_weston \\
   --group-add 104"
-    ;;
-  esac
+      ;;
+    esac
+  fi
 
   # connect to systemd from host
   Xc_systemd="\\
@@ -5506,6 +5512,7 @@ check_backend() {               # options --backend, --rootless
   unprivileged user namespace setup. Please run as root:
     sysctl -w kernel.unprivileged_userns_clone=1"
       store_runoption cap "CHOWN"
+      check_optionset "--keep-groups" "--runtime=runc --group-add" || error "Option --keep-groups incompatible with --group-add"
     ;;
     nerdctl)
       note "Option --backend=nerdctl: Support of nerdctl is experimental yet.
@@ -6162,10 +6169,15 @@ create_backendcommand() {       ### create command to run docker|podman|nerdctl 
   [ "$Switchcontaineruser" = "no" ] && {
     case "$Backend" in
       docker|podman)
-        for Line in $Containerusergroups; do
-          mygetent group "${Line:-nonsense}" >/dev/null && Backendcommand="$Backendcommand \\
+	if [ "$Keepgroups" = "yes" ]; then
+          Backendcommand="$Backendcommand \\
+  --group-add keep-groups"
+	else
+          for Line in $Containerusergroups; do
+            mygetent group "${Line:-nonsense}" >/dev/null && Backendcommand="$Backendcommand \\
   --group-add $(mygetent group "$Line" | cut -d: -f3)"
-        done
+          done
+	fi
       ;;
     esac
   }
@@ -9194,7 +9206,7 @@ parse_options() {               # parse cli options
   Longoptions="$Longoptions,alsa::,clipboard::,gpu::,lang::,printer::,pulseaudio::,webcam"                                  # Host integration features
   Longoptions="$Longoptions,backend:,env:,mobyvm,name:,no-entrypoint,no-setup,rootfs,rootless::,runtime:,snap,workdir:"     # Container config
   Longoptions="$Longoptions,cap-default,ipc::,limit::,newprivileges::,network::"                                            # Container capabilities
-  Longoptions="$Longoptions,group-add:,hostuser:,password::,sudouser::,user:,shell:"                                        # Container user
+  Longoptions="$Longoptions,group-add:,keep-groups,hostuser:,password::,sudouser::,user:,shell:"                            # Container user
   Longoptions="$Longoptions,dbus::,init::,hostdbus,sharecgroup"                                                             # Container init and DBus
   Longoptions="$Longoptions,stdin,interactive"                                                                              # Container interaction
   Longoptions="$Longoptions,runasuser:,runfromhost:,runasroot:"                                                             # Additional commands to execute
@@ -9336,6 +9348,7 @@ ${2:-}"                       ; shift ;;                             # Add custo
 
      #### User settings
          --group-add)         Containerusergroups="$Containerusergroups ${2:-}" ; shift ;; # Additional groups for container user
+	 --keep-groups)       Keepgroups="yes" ;;                    # Keep user groups
          --hostuser)          Hostuser="${2:-}" ; shift ;;           # Set host user different from logged in user
          --password)          Containeruserpassword="${2:-INTERACTIVE}" ; shift ;; # Change encrypted password in ~/.config/x11docker/passwd
          --shell)             Containerusershell="${2:-}" ; shift ;; # Set preferred user shell
@@ -11171,6 +11184,7 @@ declare_variables() {           # declare global variables
   Presetdirsystem="/etc/x11docker/preset"         # --preset storage dir (system)
   Presetlist=""                                   # List of already parsed preset files to avoid a loop
   Preservecachefiles="no"                         # If yes, don't delete cache files on exit. For few failure cases only.
+  Keepgroups="no"                                 # If yes, use host-user groups instead of using --add-groups
 
   # Verbosity options
   Debugmode="no"                                  # --debug: Excerpt of --verbose, also bash error checks


### PR DESCRIPTION
This is an attempt to address #518
I think it may need more checking to check the proper configuration (--backend=podman, --runtime=crun, --group-add not specified) but I got lost trying to understand how the argument checkers work.