### PR TITLE
Fix discrepancies in parser scripts, bad newlines in cmdrc

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -1035,26 +1035,26 @@ parse_inspect() {               # parse json of inspect output using python
   local Parserscript
   local Jsonstring Keystring Output
 
-  command -v jq >/dev/null && {
+  [[ "$Jqbin" ]] && {
     Jsonstring="${1:-}" ; shift
-    [ "${Jsonstring:0:1}" = "[" ] && Keystring=".[]" || Keystring=""
+    [[ $("$Jqbin" -r 'type' <<< "$Jsonstring") == array ]] && Keystring=".[0]" || Keystring=""
     while [ $# -gt 0 ]; do
       Keystring="$Keystring.${1:-}"
       shift
     done
-    Output="$(jq "$Keystring" <<< "$Jsonstring")"
-    while [ "${Output:0:1}" = "[" ]; do
-      Output="$(jq '.[]' <<< "$Output" )"
-    done
+    Output="$("$Jqbin" "$Keystring" <<< "$Jsonstring")"
+    if [[ $("$Jqbin" -r 'type' <<< "$Output") == array ]]; then
+      Output="$("$Jqbin" -r $'map(tostring | "\'" + . + "\'") | join(" ")' <<< "$Output" )"
+    fi
+    if [[ $("$Jqbin" -r 'type' <<< "$Output" 2>/dev/null) == string ]]; then
+        Output="$("$Jqbin" -r '.' <<< "$Output")"
+    fi
     [ "$Output" = "null" ] && Output=""
-    [ "${Output:0:1}" = '"' ] && Output="${Output:1:-1}"
     echo "$Output"
     return
   }
 
-  Parserscript="$Cachefolder/parse_inspect.py"
-  Parserscript="#! $Pythonbin
-$(cat << EOF
+  Parserscript="#! $Pythonbin"$'
 import json,sys
 
 def parse_inspect(*args):
@@ -1066,16 +1066,17 @@ def parse_inspect(*args):
      2..n: json keys. For second level keys provide e.g. "Config","Cmd"
     Prints key value as a string.
     Prints empty string if key not found.
-    A list is printed as a string with '' around each element.
+    A list is printed as a string with \'\' around each element.
     """
 
     output=""
     inspect=args[1]
     inspect=inspect.strip()
-    if inspect[0] == "[" :
-        inspect=inspect[1:-2] # remove enclosing [ ]
 
     obj=json.loads(inspect)
+
+    if "\'list\'" in str(type(obj)):
+        obj = obj[0]
 
     for arg in args[2:]: # recursively find the desired object. Command.Cmd is found with args "Command" , "Cmd"
         try:
@@ -1084,11 +1085,12 @@ def parse_inspect(*args):
             obj=""
 
     objtype=str(type(obj))
-    if "'list'" in objtype:
+    if "\'list\'" in objtype:
         for i in obj:
-            output=output+"'"+str(i)+"' "
+            output += "\'" + str(i) + "\' "
+        output = output.strip()
     else:
-        output=str(obj)
+        output = str(obj)
 
     if output == "None":
         output=""
@@ -1096,8 +1098,7 @@ def parse_inspect(*args):
     print(output)
 
 parse_inspect(*sys.argv)
-EOF
-  )"
+'
   echo "$Parserscript" | $Pythonbin - "$@" || warning "parse_inspect(): Error while parsing json for
   ${2:-} ${3:-} ${4:-} ${5:-} ${6:-} (Line $BASH_LINENO)"
 }
@@ -5675,7 +5676,11 @@ check_image() {                 # get some image information
 
   # Check WORKDIR
   Imageworkdir="$(parse_inspect "$Imageinspect" "Config" "Workdir")"
-  debugnote "Image WORKDIR: $Workdir"
+  # It seems Config.Workdir is Config.WorkingDir in more recent versions?
+  [ -z "$Imageworkdir" ] && {
+    Imageworkdir="$(parse_inspect "$Imageinspect" "Config" "WorkingDir")"
+  }
+  debugnote "Image WORKDIR: $Imageworkdir"
   [ -z "$Workdir" ] && [ -n "$Imageworkdir" ] && {
     note "Found 'WORKDIR $Imageworkdir' in image.
   You can change it with option --workdir=DIR."
@@ -7406,20 +7411,18 @@ done
     # --runasuser commands added here
     [ -n "$Runasuser" ] && {
       while read Line; do
-        echo "
-debugnote 'cmdrc: running --runsasuser command:
-  $Line'
-"
+        # The echoed string containing the debugnote command should not contain a newline character
+        # to avoid problems with the generated cmdrc.
+        echo "debugnote \"cmdrc: running --runsasuser command: $Line\""
         echo "
 $Line
 "
       done <<< "$(grep . <<< "$Runasuser")"
     }
 
-    echo "
-debugnote \"cmdrc: Running container command:
-  $Containerentrypoint $Containercommand\"
-"
+    # The echoed string containing the debugnote command should not contain a newline character
+    # to avoid problems with the generated cmdrc.
+    echo "debugnote \"cmdrc: Running container command: $Containerentrypoint $Containercommand\""
     case "$Forwardstdin" in
       yes) echo "$Containerentrypoint $Containercommand <$(convertpath share "$Cmdstdinfifo")" ;;
       no)  echo "$Containerentrypoint $Containercommand" ;;
@@ -8749,13 +8752,14 @@ check_host() {                  # check host environment
   #Nvidiaversion="470.74"
 
   # check python version
-  Pythonbin="$(command -v jq ||:)"
-  [ -z "$Pythonbin" ] && Pythonbin="$(command -v python ||:)"
+  Pythonbin="$(command -v python ||:)"
   [ -z "$Pythonbin" ] && Pythonbin="$(command -v python3 ||:)"
   [ -z "$Pythonbin" ] && Pythonbin="$(command -v python2 ||:)"
+  # check jq version
+  Jqbin="$(command -v jq ||:)"
   case "$Backend" in
     docker|podman|nerdctl)
-      [ -z "$Pythonbin" ] && error "x11docker needs 'jq' or 'python' to parse output
+      [ -z "$Pythonbin" ] && [ -z "$Jqbin" ] && error "x11docker needs 'jq' or 'python' to parse output
   of '$Backend inspect'. Please install 'jq' or 'python' version 2.x or 3.x."
     ;;
   esac
@@ -10981,6 +10985,7 @@ declare_variables() {           # declare global variables
   Nvidiaversion=""                                # --gpu: Proprietary nvidia driver version on host
   Nvidiainstallerfile=""                          # --gpu: Proprietary nvidia driver installer for container in [...]local/share/x11docker
   Pythonbin=""                                    # path to python binary
+  Jqbin=""                                        # path to jq binary
 
   # MS Windows
   Winpty=""                                       # Path to winpty for --interactive on MS Windows

--- a/x11docker
+++ b/x11docker
@@ -1037,15 +1037,19 @@ parse_inspect() {               # parse json of inspect output using python
 
   [[ "$Jqbin" ]] && {
     Jsonstring="${1:-}" ; shift
-    [[ $("$Jqbin" -r 'type' <<< "$Jsonstring") == array ]] && Keystring=".[0]" || Keystring=""
+    # If we have an array, get the first item
+    [[ $("$Jqbin" -r 'type' <<< "$Jsonstring" 2>/dev/null) == array ]] && Keystring=".[0]" || Keystring=""
+    # Recursively find key using the sequence of keys
     while [ $# -gt 0 ]; do
       Keystring="$Keystring.${1:-}"
       shift
     done
     Output="$("$Jqbin" "$Keystring" <<< "$Jsonstring")"
-    if [[ $("$Jqbin" -r 'type' <<< "$Output") == array ]]; then
+    # If we have an array, single-quote each item and join with spaces
+    if [[ $("$Jqbin" -r 'type' <<< "$Output" 2>/dev/null) == array ]]; then
       Output="$("$Jqbin" -r $'map(tostring | "\'" + . + "\'") | join(" ")' <<< "$Output" )"
     fi
+    # If we have a string, output the raw contents without quotes
     if [[ $("$Jqbin" -r 'type' <<< "$Output" 2>/dev/null) == string ]]; then
         Output="$("$Jqbin" -r '.' <<< "$Output")"
     fi

--- a/x11docker
+++ b/x11docker
@@ -5413,6 +5413,19 @@ check_backend() {               # options --backend, --rootless
     host) Backendbin="" ;;
   esac
 
+  case "$Backend" in
+    docker|podman|nerdctl)
+      if [ -n "$Jqbin" ]; then
+        debugnote "check_backend(): will parse json using $Jqbin"
+      elif [ -n "$Pythonbin" ]; then
+        debugnote "check_backend(): will parse json using $Pythonbin"
+      else
+        error "x11docker needs 'jq' or 'python' to parse output of '$Backend inspect'.
+  Please install 'jq' or 'python' version 2.x or 3.x."
+      fi
+    ;;
+  esac
+
   # rootful or rootless
   [ "$Backendrootless" = "no" ] && export DOCKER_HOST=
   [ -z "$Backendrootless" ] && case "$Backend" in
@@ -8607,7 +8620,7 @@ check_console() {               # check whether x11docker runs on console
   id "$Hostuser" | grep -q -e "(tty)" -e "(root)" || {
     unpriv "fgconsole" >/dev/null 2>&1 && Runsonconsole="yes"
   }
-  debugnote "check_host(): Guess if running on console: $Runsonconsole"
+  debugnote "check_console(): Guess if running on console: $Runsonconsole"
 }
 check_fallback() {              # --fallback
   # Option --fallback
@@ -8757,12 +8770,17 @@ check_host() {                  # check host environment
   [ -z "$Pythonbin" ] && Pythonbin="$(command -v python2 ||:)"
   # check jq version
   Jqbin="$(command -v jq ||:)"
-  case "$Backend" in
-    docker|podman|nerdctl)
-      [ -z "$Pythonbin" ] && [ -z "$Jqbin" ] && error "x11docker needs 'jq' or 'python' to parse output
-  of '$Backend inspect'. Please install 'jq' or 'python' version 2.x or 3.x."
-    ;;
-  esac
+
+  # The strict check for at least one of these will happen in check_backend.
+  if [ -n "$Jqbin" ]; then
+    debugnote "check_host(): found $Jqbin"
+  fi
+  if [ -n "$Pythonbin" ]; then
+    debugnote "check_host(): found $Pythonbin"
+  fi
+  if [ -z "$Jqbin" ] && [ -z "$Pythonbin" ]; then
+    debugnote "x11docker needs 'jq' or 'python' to parse output for some backends, but neither was found."
+  fi
 
   return 0
 }


### PR DESCRIPTION
There were discrepancies between the jq and python versions of the injected parser script for the container info. In particular, the jq version was behaving badly and injecting newlines into the parsed result. Further, the generated cmdrc was splitting some messages with newlines, causing erroneous commands.

I posted an old/new comparison with output here (note the issue with test 3 especially):
https://github.com/echuber2/x11docker-parser-test

Fixes https://github.com/mviereck/x11docker/issues/485
Fixes https://github.com/mviereck/x11docker/issues/493
Fixes https://github.com/mviereck/x11docker/issues/504

(I hope others can test and confirm the fixed issues. There may have been additional issues related to this. **Test at your own risk. I can't guarantee this won't remove files unexpectedly based on the parsed results.**)

The issues with parsing here make me nervous for safety of using the scripts, especially in relation to the cleanup command that removes files and directories. I hope I haven't made things any worse with these changes.

Since the container runtimes have a built-in parser (using `--format`, [see the Docker docs for example](https://docs.docker.com/engine/reference/commandline/inspect/#format)), maybe it would be better to remove these parsers entirely and just let the runtime fetch what you need. Or, make one of either jq or python a hard requirement, to at least ensure consistency or simplify testing. I suppose that jq is smaller than python to keep as a system requirement, but the python version might be easier to debug and maintain.