### PR TITLE
Fix issues with --password

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -11418,15 +11418,15 @@ main() {
     set -Eu
     trap 'traperror $? $LINENO $BASH_LINENO "$BASH_COMMAND" $(printf "::%s" ${FUNCNAME[@]})'  ERR
   }
+  check_host                     # get some infos about host system
+  check_options_arguments        # check for valid arguments
+  check_hostuser                 # find unprivileged host user                    # --hostuser
   [ -n "$Containeruserpassword" ] && {                                            # --password
     check_optionset "--password" "$(grep -v -- '--password' <<< "$Optionsetall")" ||:
     set_password "$Containeruserpassword"
     finish
     return 0
   }
-  check_host                     # get some infos about host system
-  check_options_arguments        # check for valid arguments
-  check_hostuser                 # find unprivileged host user                    # --hostuser
   check_console                  # check if running on console
   create_cachefiles              # create cache files owned by unprivileged user  # --cachebasedir
   setup_verbosity                # create [and show] summary logfile              # --verbose

--- a/x11docker
+++ b/x11docker
@@ -1371,6 +1371,7 @@ mkfile() {                      # create file $1 owned by $Hostuser
   return 0
 }
 mkfolder() {                    # create folder $1 owned by $Hostuser
+  assert_unpriv_defined
   local Step Path= Return=
   for Step in $(tr '/' '\n' <<< "${1:-}" | grep .) ; do
     Path="$Path/$Step"
@@ -11349,14 +11350,26 @@ experimental() {
   }
   return 1
 }
+assert_unpriv_defined() {
+  if [ -z "$Unpriv" ] ; then
+    # The error function doesn't seem to work correctly in the contexts where this is called, so echo and fail fast to be sure.
+    local unpriv_check_msg
+    unpriv_check_msg='Error: Variable Unpriv should have been set by now. This means check_hostuser needs to run earlier (maybe a bug).'
+    echo "$unpriv_check_msg"
+    echo "$unpriv_check_msg" >&2
+    exit 1
+  fi
+}
 unpriv() {                      # run a command as unprivileged user. Needed if x11docker was started by root or with sudo.
   # $Unpriv is declared in check_hostuser: 'eval' or 'su $Hostuser -c'
+  assert_unpriv_defined
   local Command
   Command="$(oneline "${1:-}")"
   $Unpriv "$Command"
   return $?
 }
 unpriv_backend() {              # run container backend rootful or rootless
+  assert_unpriv_defined
   local Command
   Command="$(oneline "${1:-}")"
   [ -z "$Backendbin" ] && {
@@ -11370,6 +11383,7 @@ unpriv_backend() {              # run container backend rootful or rootless
   return $?
 }
 unpriv_xcbackend() {            # run X container backend rootful or rootless
+  assert_unpriv_defined
   local Command
   Command="$(oneline "${1:-}")"
   case "${Xcrootless:-no}" in

--- a/x11docker
+++ b/x11docker
@@ -1909,9 +1909,22 @@ set_password() {                # option --password: set container user password
   }
   mkpasswd "$Password"
 
-  mkfolder "$(dirname "$Passwordfile")"
-  echo "$Containeruserpassword" > "$Passwordfile"
-  chmod 600                       "$Passwordfile"
+  local PasswordfileDirectory
+  PasswordfileDirectory="$(dirname "$Passwordfile")"
+  mkfolder "$PasswordfileDirectory"
+  (
+    echo "$Containeruserpassword" > "$Passwordfile" || exit 1
+    chmod 600                       "$Passwordfile" || exit 1
+  ) || {
+    local error_msg
+    error_msg="Error modifying file \"$Passwordfile\". If it already exists, check the ownership of the file."
+    if [ ! -w "$PasswordfileDirectory" ] ; then
+      error_msg="$error_msg Also, the parent directory \"$PasswordfileDirectory\" is not writable by current user \"$Hostuser\"."
+    fi
+    error "$error_msg"
+    return 1 # will not execute after error
+  }
+
   note "Option --password: Password changed, exiting."
   return 0
 }

--- a/x11docker
+++ b/x11docker
@@ -1372,16 +1372,15 @@ mkfile() {                      # create file $1 owned by $Hostuser
 }
 mkfolder() {                    # create folder $1 owned by $Hostuser
   assert_unpriv_defined
-  local Step Path= Return=
+  local Step Path=
   for Step in $(tr '/' '\n' <<< "${1:-}" | grep .) ; do
     Path="$Path/$Step"
-    [ -d "$Path" ] || {
-      unpriv "mkdir -p  '$Path'"  || Return=1
-      chmod "${2:-755}" "$Path"   || Return=1
-    }
-    [ "$Return" ] && break
+    if [ ! -d "$Path" ] ; then
+      unpriv "mkdir -p  '$Path'" || return 1
+      chmod "${2:-755}" "$Path"  || return 1
+    fi
   done
-  return ${Return:-0}
+  return 0
   #unpriv "mkdir -p  '${1:-}'"   || return 1
 }
 myrealpath() {                  # real path of possible symlink


### PR DESCRIPTION
There are problems with using `--password` because `set_password` is called before `check_hostuser`, but `check_hostuser` is where `Unpriv` gets set, which `set_password` relies on. This PR defers the `set_password` call until after `check_hostuser`, and it also adds some error checking (based on what I used to debug the issue).