### PR TITLE
README.md: Improve browser stability with fixed shared memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ x11docker --build x11docker/fvwm
 | [Kodi media center](https://kodi.tv/) with hardware <br> acceleration, Pulseaudio sound <br> and shared `Videos` folder. <br> For setup look at [ehough/docker-kodi](https://github.com/ehough/docker-kodi). | `x11docker --gpu --pulseaudio --share ~/Videos erichough/kodi`. |
 | [XaoS](https://github.com/patrick-nw/xaos) fractal generator | `x11docker patricknw/xaos` |
 | [Telegram messenger](https://telegram.org/) with persistent <br> `HOME` for configuration storage | `x11docker --home xorilog/telegram` |
-| Firefox with shared `Download` folder<br> and internet access. | `x11docker -I --share $HOME/Downloads -- --tmpfs /dev/shm -- jess/firefox` |
+| Firefox with shared `Download` folder<br> and internet access. | `x11docker -I --share $HOME/Downloads -- --tmpfs /dev/shm:size=500M -- jess/firefox` |
 | [Tor browser](https://www.torproject.org/projects/torbrowser.html) | `x11docker -I jess/tor-browser` |
 | Chromium browser with restricted resource usage | `x11docker -I --limit -- jess/chromium --no-sandbox` |
 | VLC media player with shared `Videos` <br> folder and Pulseaudio sound | `x11docker --pulseaudio --share=$HOME/Videos jess/vlc` |


### PR DESCRIPTION
I had problems testing in resource constrained environments and found this little solution

With this config you can set up the ammount size of the shm file
By default the size is half of the available RAM (https://docs.docker.com/engine/storage/tmpfs/#:~:text=If%20unset%2C%20the%20default%20maximum,of%20the%20host's%20total%20RAM.&text=File%20mode%20of%20the%20tmpfs,to%201777%20or%20world%2Dwritable.)