### PR TITLE
fix: correct typo readomly -> readonly in mount option

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -1379,7 +1379,7 @@ createmountopt(){               # create option to mount file or device, check i
   case "$Rw" in
     "ro"|"readonly")
       case "$Modus" in
-        mount)         Rw=",readomly" ;;
+        mount)         Rw=",readonly" ;;
         volume|device) Rw=":ro" ;;
       esac
     ;;


### PR DESCRIPTION
Fixes #565

Corrects the typo `,readomly` → `,readonly` in the mount option generation.

**Change:** 1 line in `x11docker` (line 1382)