### PR TITLE
add missing arg, value:  "$Xiniterrorcodes"

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -12672,7 +12672,7 @@ $(nl -ba <$Xinitrc)"
   case "$Xserver" in
     --xpra*)
       {
-        waitforlogentry xpra $Xinitlogfile "xinitrc is ready" infinity
+        waitforlogentry xpra $Xinitlogfile "xinitrc is ready" "$Xiniterrorcodes" infinity
         rocknroll && start_xpra                                                   # --xpra, --xpra-xwayland
       } & storepid $! xpraloop
     ;;


### PR DESCRIPTION
https://github.com/mviereck/x11docker/issues/568

This PR adds the missing argument. The value is copied from
from a similar call with "xinitrc is ready" :

`waitforlogentry 'start_container()' $Xinitlogfile 'xinitrc is ready' "$Xiniterrorcodes"`