### PR TITLE
Runfromhost: only non-empty, only lines

### DIFF
--- a/x11docker
+++ b/x11docker
@@ -12595,12 +12595,13 @@ $(nl -ba <$Sshenvscript)"
     # xinit(?) sets variables to new display for host applications, too. This undoes it.
     unpriv "dbus-update-activation-environment --systemd DISPLAY='$DISPLAY' XAUTHORITY='$XAUTHORITY'" >> "$Xinitlogfile" 2>&1 ||:
 
-    [ "$Runfromhost" ] && {                                                       # --runfromhost
+    if [ -n "$Runfromhost" ] ; then # --runfromhost
       while read Line; do
-        unpriv "env $Newxenv $Runfromhost"
+        if [ -n "$Line" ] ; then
+            unpriv "env $Newxenv $Line"
+        fi
       done <<< "$Runfromhost"
-    }
-
+    fi
     # start container
     start_container
     Pid1pid="$(storeinfo dump pid1pid)"


### PR DESCRIPTION
https://github.com/mviereck/x11docker/issues/578

* run only lines of Runfromhost
* run only non-empty lines of Runfromhost